### PR TITLE
Fix spriteZeroHit to not turn off

### DIFF
--- a/src/Emulator/PPU.hs
+++ b/src/Emulator/PPU.hs
@@ -157,7 +157,8 @@ getComposedColor (x, y) bg sprite = do
       | not b && s = pure $ sc .|. 0x10
       | b && not s = pure bg
       | otherwise = do
-        storePpu spriteZeroHit (ind == 0 && x < 255)
+        when (ind == 0 && x < 255) $
+          storePpu spriteZeroHit True
         if priority == 0 then
           pure $ sc .|. 0x10
         else


### PR DESCRIPTION
Sprite zero hit becomes True when it is occurred.
If it happens, it should keep True
until Vblank end.

This change fixes flickering on Super Mario Bros.